### PR TITLE
Return DoubleEndedIterator for iter method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "range_map_vec"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "range_map_vec is an implementation of a range map data structure backed by a Vec."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ where
     }
 
     /// Provides an iterator to iterate through the whole map.
-    pub fn iter(&self) -> impl Clone + Iterator<Item = (RangeInclusive<K>, &V)> {
+    pub fn iter(&self) -> impl Clone + DoubleEndedIterator<Item = (RangeInclusive<K>, &V)> {
         self.data
             .iter()
             .map(|(start, end, v)| (start.clone()..=end.clone(), v))


### PR DESCRIPTION
Return a `DoubleEndedIterator ` which allows the user to use methods that require that, such as `.rev()`. Bump the version to 0.2.0 for publishing, with a minor version bump as this is a breaking change. 